### PR TITLE
Compare JSON on update

### DIFF
--- a/custom_news_feed/custom_news_feed.py
+++ b/custom_news_feed/custom_news_feed.py
@@ -677,7 +677,7 @@ class CustomNewsFeed:
             self.iface.messageBar().pushMessage("Fehler im Custom News Feed Plugin",
                 self.tr(u'Die Datei ') + path +
                 self.tr(u' konnte nicht gelesen werden. ') +
-                self.tr(u'Mehr Informationen im QGis message log. Beispielhafe News werden angezeigt.'),
+                self.tr(u'Mehr Informationen im QGis message log. Beispielhafte News werden angezeigt.'),
                 level = Qgis.Critical)
             QgsMessageLog.logMessage(u'Error reading file ' + str(e),'Custom News Feed')
             with open(os.path.join(self.plugin_dir, 'sample_news','sample_news.json'),'r', encoding='utf-8') as f:

--- a/custom_news_feed/custom_news_feed.py
+++ b/custom_news_feed/custom_news_feed.py
@@ -265,17 +265,8 @@ class CustomNewsFeed:
 
     def display_news_content(self, news_json_file_path):
         """Display content of JSON-file in plugin."""
-        json_tree = self.get_text_content_from_path(news_json_file_path)
         try:
-            news = json.loads(json_tree)
-        except Exception as e:
-            print(str(e))
-            self.iface.messageBar().pushMessage("Fehler im Custom News Feed Plugin",
-                    self.tr(u'JSON-file konnte nicht geladen werden. ') +
-                    self.tr(u'Mehr Informationen im QGis message log.'),
-                    level = Qgis.Critical)
-            QgsMessageLog.logMessage(u'Error Initializing Config file ' + str(e),'Custom News Feed')
-        try:
+            news = self.load_json_from_file(self, news_json_file_path)
             self.readbuttonlabel = news['ReadButtonLabel']
             self.readallbuttonlabel = news["ReadAllButtonLabel"]
             self.timer.start(news['NewsRefreshInterval'] * 60000 ) # convert minutes in miliseconds
@@ -643,7 +634,7 @@ class CustomNewsFeed:
         self.settings_dlg.config_json_path.setText(path)
 
 
-    def get_text_content_from_path(self, path):
+    def load_json_from_file(self, path):
         """Gets the text content from a path. May be a local path, or an url"""
         txt = None
         QApplication.setOverrideCursor(Qt.WaitCursor)
@@ -677,4 +668,14 @@ class CustomNewsFeed:
                 txt = f.read()
         finally:
                 QApplication.restoreOverrideCursor()
-        return txt
+
+        try:
+            json_content = json.loads(txt)
+        except Exception as e:
+            print(str(e))
+            self.iface.messageBar().pushMessage("Fehler im Custom News Feed Plugin",
+                    self.tr(u'JSON-file konnte nicht geladen werden. ') +
+                    self.tr(u'Mehr Informationen im QGis message log.'),
+                    level = Qgis.Critical)
+            QgsMessageLog.logMessage(u'Error Initializing Config file ' + str(e),'Custom News Feed')
+        return json_content

--- a/custom_news_feed/custom_news_feed.py
+++ b/custom_news_feed/custom_news_feed.py
@@ -266,7 +266,7 @@ class CustomNewsFeed:
     def display_news_content(self, news_json_file_path):
         """Display content of JSON-file in plugin."""
         try:
-            news = self.load_json_from_file(self, news_json_file_path)
+            news = self.load_json_from_file(news_json_file_path)
             self.readbuttonlabel = news['ReadButtonLabel']
             self.readallbuttonlabel = news["ReadAllButtonLabel"]
             self.timer.start(news['NewsRefreshInterval'] * 60000 ) # convert minutes in miliseconds

--- a/custom_news_feed/custom_news_feed.py
+++ b/custom_news_feed/custom_news_feed.py
@@ -277,17 +277,7 @@ class CustomNewsFeed:
             self.settings_dlg.pathToConfigurationFileLabel.setText(news["PathToConfigurationFileLabel"])
             self.settings_dlg.openPanelOnNewsCheckBox.setText(news["OpenPanelOnNewsCheckBoxLabel"])
 
-            self.current_pinned_message = news["PinnedMessage"]
-            pinnedmessage = json.dumps(news["PinnedMessage"])
-
-            if 'StartPublishingDate' in json.loads(pinnedmessage) and 'EndPublishingDate' in json.loads(pinnedmessage):
-                if self.checkPublishingDate(news["PinnedMessage"]['StartPublishingDate'],news["PinnedMessage"]['EndPublishingDate']) == True:
-                    self.configure_pinned_message(news["PinnedMessage"])
-                else:
-                    self.dockwidget.pinned_message.setVisible(False)
-            else:
-                self.configure_pinned_message(news["PinnedMessage"])
-
+            self.add_pinned_message(news["PinnedMessage"])
             self.addNews(news["NewsArticles"])
             self.addLinks(news["Links"])
 
@@ -330,6 +320,18 @@ class CustomNewsFeed:
                     self.dockwidget.pinned_message.setStyleSheet("background:rgb(255, 85, 0);padding:8px;")
                 else:
                     self.dockwidget.pinned_message.setStyleSheet("background:rgb(173,216,230);padding:8px;")
+
+    def add_pinned_message(self, pinnedMessageJson):
+        self.current_pinned_message = pinnedMessageJson
+        pinnedmessage = json.dumps(self.current_pinned_message)
+
+        if 'StartPublishingDate' in json.loads(pinnedmessage) and 'EndPublishingDate' in json.loads(pinnedmessage):
+            if self.checkPublishingDate(self.current_pinned_message['StartPublishingDate'],self.current_pinned_message['EndPublishingDate']) == True:
+                self.configure_pinned_message(self.current_pinned_message)
+            else:
+                self.dockwidget.pinned_message.setVisible(False)
+        else:
+            self.configure_pinned_message(self.current_pinned_message)
 
 
     def addLinks(self, links):

--- a/custom_news_feed/custom_news_feed.py
+++ b/custom_news_feed/custom_news_feed.py
@@ -398,11 +398,13 @@ class CustomNewsFeed:
 
     def mark_all_as_read(self, newsArticles):
         """Mark all news as read"""
+        QApplication.setOverrideCursor(Qt.WaitCursor)
         for index, newsArticle in enumerate(newsArticles):
             startdate, enddate = self.getStartEndDate(newsArticle)
             if self.check_hashfile(newsArticle["Hash"]) == False and self.checkPublishingDate(startdate, enddate) == True:
                 self.create_hashfile(newsArticle["Hash"], True)
         self.get_news()
+        QApplication.restoreOverrideCursor()
 		
     def getStartEndDate(self, newsArticle):
         """Check the existence of a publishing date range"""

--- a/custom_news_feed/custom_news_feed.py
+++ b/custom_news_feed/custom_news_feed.py
@@ -429,7 +429,6 @@ class CustomNewsFeed:
             previousNewsArcticles = previousNewsJson["NewsArticles"]
             hasNewArticles = False
         else:
-            previousNewsArcticles = []
             hasNewArticles = True
 
         for index, newsArticle in enumerate(newsArticles):


### PR DESCRIPTION
Die Funktionalität wurde vor allem mit [Compare to previous news](https://github.com/GeoWerkstatt/qgis-custom-news-feed/commit/6020e82cf792f17af83042995663abc41442d3e4) committet, die anderen Commits sind Refactorings oder Verbesserungen. 

Getestete Szenarien:
- Es existiert noch kein _previous-news.json_ -> Messagebar wird angezeigt
- Eine Nachricht wird inhaltlich verändert -> Messagebar wird angezeigt
- Eine Nachricht kommt dazu -> Messagebar wird angezeigt
- Eine Nachricht wird aus der Liste gelöscht -> Messagebar wird nicht angezeigt
- Keine Veränderung im JSON-> Messagebar wird nicht angezeigt
- Nachrichten wurden als gelesen markiert -> Messagebar wird nicht angezeigt